### PR TITLE
Fix: Bio overlapping navbar, nav links scrolling too far

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -83,3 +83,6 @@
     padding: 1%;
   }
 }
+section {
+  scroll-margin-top: 125px;
+}

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -9,7 +9,6 @@
     margin: .5rem;
     color: white;
     height: 500px;
-    z-index: 1;
 }
 
 .bio {
@@ -28,7 +27,6 @@
     position: relative;
     top: 14rem;
     left: 6rem;
-    z-index: 1;
 }
 
 @media (max-width: 830px) {

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -28,6 +28,7 @@
     position: relative;
     top: 14rem;
     left: 6rem;
+    z-index: 1;
 }
 
 @media (max-width: 830px) {

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -9,6 +9,7 @@
     margin: .5rem;
     color: white;
     height: 500px;
+    z-index: 1;
 }
 
 .bio {

--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -1,6 +1,7 @@
 header {
     position: sticky;
     top: 0;
+    z-index: 2;
 }
 nav{
     display: flex;


### PR DESCRIPTION
Added `z-index: 2;` property to header element styles.
Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/z-index

Added `scroll-margin-top: 125px;` property to section element styles.
Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin